### PR TITLE
Fix mobile layout: make YouTube iframe responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
                     <p class="text-[10px] uppercase tracking-[0.45em] text-white/50">Test Fire Video</p>
                     <div class="relative overflow-hidden border-2 border-white/30 bg-black/50">
                       <div class="relative w-full aspect-video">
-                        <iframe width="560" height="315" src="https://www.youtube.com/embed/zV76q70wpXw?si=A7-clo6rBnN3wy7d" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                        <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/zV76q70wpXw?si=A7-clo6rBnN3wy7d" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Removed hardcoded width="560" height="315" attributes from the iframe
and added absolute inset-0 w-full h-full classes so it fills the
aspect-video wrapper. The fixed dimensions were causing horizontal
overflow on mobile, making the video and text appear outside the
bounding article box.

https://claude.ai/code/session_01XqPhYojgzqPyVB61XQT7iU